### PR TITLE
Support for choosing number of questions to be used

### DIFF
--- a/src/docs/quiz.jsx
+++ b/src/docs/quiz.jsx
@@ -7,6 +7,7 @@ const segment = {
 export const quiz =  {
   "quizTitle": "React Quiz Component Demo",
   "quizSynopsis": "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim",
+  "nrOfQuestions": "2",
   "questions": [
     {
       "question": "How can you access the state of a component from inside of a member function?",

--- a/src/lib/Quiz.jsx
+++ b/src/lib/Quiz.jsx
@@ -10,7 +10,7 @@ const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, 
 
   useEffect(() => {
     if(shuffle) {
-      setQuestions(shuffleQuestions(quiz.questions));
+      setQuestions(shuffleQuestions(quiz.questions, quiz.nrOfQuestions ? quiz.nrOfQuestions : quiz.questions.length ));
     } else {
       setQuestions(quiz.questions);
     }
@@ -22,11 +22,13 @@ const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, 
 
   }, [start])
 
-  const shuffleQuestions = useCallback((questions) => {
-    for (let i = questions.length - 1; i > 0; i--) {
+  const shuffleQuestions = useCallback((questions, nrOfQuestions) => {
+    for (let i = nrOfQuestions - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
+      console.log("j", j);
       [questions[i], questions[j]] = [questions[j], questions[i]];
     }
+    questions.length = nrOfQuestions;
     return questions;
   }, [])
 
@@ -36,13 +38,8 @@ const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, 
       return false;
     }
 
-    const { questions } = quiz;
-    if(!questions ) {
-      console.error("Field 'questions' is required.");
-      return false;
-    }
-
     for(let i=0; i<questions.length; i++) {
+      console.log("questions.length: ", questions.length)
       const { question, questionType, questionPic, answerSelectionType, answers, correctAnswer } = questions[i];
       if(!question) {
         console.error("Field 'question' is required.");
@@ -109,7 +106,7 @@ const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, 
         {!start &&
           <div>
             <h2>{quiz.quizTitle}</h2>
-            <div>{appLocale.landingHeaderText.replace("<questionLength>" , quiz.questions.length)}</div>
+            <div>{appLocale.landingHeaderText.replace("<questionLength>" , quiz.nrOfQuestions ? quiz.nrOfQuestions : quiz.questions.length)}</div>
             {quiz.quizSynopsis &&
               <div className="quiz-synopsis">
                   {quiz.quizSynopsis}

--- a/src/lib/Quiz.jsx
+++ b/src/lib/Quiz.jsx
@@ -7,7 +7,7 @@ import "./styles.css";
 const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, showInstantFeedback, continueTillCorrect }) => {
   const [start, setStart] = useState(false)
   const [questions, setQuestions] = useState(quiz.questions)
-  const nrOfQuestions = quiz.nrOfQuestions ? quiz.nrOfQuestions : quiz.questions.length
+  const nrOfQuestions = (quiz.nrOfQuestions && quiz.nrOfQuestions < quiz.questions.length) ? quiz.nrOfQuestions : quiz.questions.length
 
   useEffect(() => {
     if(shuffle) {

--- a/src/lib/Quiz.jsx
+++ b/src/lib/Quiz.jsx
@@ -7,11 +7,13 @@ import "./styles.css";
 const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, showInstantFeedback, continueTillCorrect }) => {
   const [start, setStart] = useState(false)
   const [questions, setQuestions] = useState(quiz.questions)
+  const nrOfQuestions = quiz.nrOfQuestions ? quiz.nrOfQuestions : quiz.questions.length
 
   useEffect(() => {
     if(shuffle) {
-      setQuestions(shuffleQuestions(quiz.questions, quiz.nrOfQuestions ? quiz.nrOfQuestions : quiz.questions.length ));
+      setQuestions(shuffleQuestions(quiz.questions));
     } else {
+      quiz.questions.length = nrOfQuestions;
       setQuestions(quiz.questions);
     }
 
@@ -22,10 +24,9 @@ const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, 
 
   }, [start])
 
-  const shuffleQuestions = useCallback((questions, nrOfQuestions) => {
+  const shuffleQuestions = useCallback((questions) => {
     for (let i = nrOfQuestions - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
-      console.log("j", j);
       [questions[i], questions[j]] = [questions[j], questions[i]];
     }
     questions.length = nrOfQuestions;
@@ -39,7 +40,6 @@ const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, 
     }
 
     for(let i=0; i<questions.length; i++) {
-      console.log("questions.length: ", questions.length)
       const { question, questionType, questionPic, answerSelectionType, answers, correctAnswer } = questions[i];
       if(!question) {
         console.error("Field 'question' is required.");
@@ -106,7 +106,7 @@ const Quiz = ({ quiz, shuffle, showDefaultResult, onComplete, customResultPage, 
         {!start &&
           <div>
             <h2>{quiz.quizTitle}</h2>
-            <div>{appLocale.landingHeaderText.replace("<questionLength>" , quiz.nrOfQuestions ? quiz.nrOfQuestions : quiz.questions.length)}</div>
+            <div>{appLocale.landingHeaderText.replace("<questionLength>" , nrOfQuestions)}</div>
             {quiz.quizSynopsis &&
               <div className="quiz-synopsis">
                   {quiz.quizSynopsis}


### PR DESCRIPTION
Adding support for setting number of questions to be used in the quiz. This to be able to shuffle for example 2 random questions out of 5 possible.  Adding number of questions to use is an option, not an obligation. Can also be used when questions are not shuffled, then it will take the first k number of questions.  