### PR TITLE
fix: Replace marked import with parse

### DIFF
--- a/src/lib/core-components/helpers.js
+++ b/src/lib/core-components/helpers.js
@@ -3,7 +3,7 @@ import dompurify from 'dompurify';
 
 export const rawMarkup = (data) => {
   const sanitizer = dompurify.sanitize;
-  return { __html: marked(sanitizer(data)) };
+  return { __html: marked.parse(sanitizer(data)) };
 };
 
 export const checkAnswer = (index, correctAnswer, answerSelectionType, {


### PR DESCRIPTION
## Problem 
Facing the following error which prevents React Quiz Component from working and crashes the app:
```
Uncaught TypeError: (0 , _marked.marked) is not a function
    at rawMarkup (helpers.js:29:1)
    at Core (Core.js:412:1)
    at renderWithHooks (react-dom.development.js:16305:1)
    at mountIndeterminateComponent (react-dom.development.js:20074:1)
    at beginWork (react-dom.development.js:21587:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:4164:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:1)
    at invokeGuardedCallback (react-dom.development.js:4277:1)
    at beginWork$1 (react-dom.development.js:27451:1)
    at performUnitOfWork (react-dom.development.js:26557:1)
rawMarkup @ helpers.js:29
Core @ Core.js:412
renderWithHooks @ react-dom.development.js:16305
mountIndeterminateComponent @ react-dom.development.js:20074
beginWork @ react-dom.development.js:21587
callCallback @ react-dom.development.js:4164
invokeGuardedCallbackDev @ react-dom.development.js:4213
invokeGuardedCallback @ react-dom.development.js:4277
beginWork$1 @ react-dom.development.js:27451
performUnitOfWork @ react-dom.development.js:26557
workLoopSync @ react-dom.development.js:26466
renderRootSync @ react-dom.development.js:26434
recoverFromConcurrentError @ react-dom.development.js:25850
performSyncWorkOnRoot @ react-dom.development.js:26096
flushSyncCallbacks @ react-dom.development.js:12042
(anonymous) @ react-dom.development.js:25651
react-dom.development.js:18687 The above error occurred in the <Core> component:

    at Core (http://localhost:3002/static/js/bundle.js:34684:24)
    at div
    at Quiz (http://localhost:3002/static/js/bundle.js:35175:19)
    at Game
    at div
    at App

Consider adding an error boundary to your tree to customize error handling behavior.
Visit https://reactjs.org/link/error-boundaries to learn more about error boundaries.
```

## Reproduce
1. Install `react-quiz-component` via npm
2. Run the sample quiz as described in the README
3. Click "Start Quiz"
4. App crashes with above error.

## Possible Solution
According to the [docs](https://marked.js.org/#usage), the right way to parse seems like to call `marked.parse`. I think `marked` itself does not do anything.

## Similar issue
- #82 
- #75 
- #79 
- https://stackoverflow.com/questions/70152561/typeerror-0-marked-webpack-imported-module-7-default-is-not-a-function