### PR TITLE
Fix #131 - Added progressbar to show quiz progress

### DIFF
--- a/src/lib/Core.jsx
+++ b/src/lib/Core.jsx
@@ -5,6 +5,7 @@ import QuizResultFilter from './core-components/QuizResultFilter';
 import { checkAnswer, selectAnswer, rawMarkup } from './core-components/helpers';
 import InstantFeedback from './core-components/InstantFeedback';
 import Explanation from './core-components/Explanation';
+import ProgressBar from './core-components/ProgressBar';
 
 const Core = function ({
   questions, appLocale, showDefaultResult, onComplete, customResultPage,
@@ -317,6 +318,8 @@ const Core = function ({
             {currentQuestionIndex + 1}
             :
           </div>
+
+          <ProgressBar progress={currentQuestionIndex + 1} />
           <h3 dangerouslySetInnerHTML={rawMarkup(`${question && question.question} ${appLocale.marksOfQuestion.replace('<marks>', question.point)}`)} />
 
           {question && question.questionPic && <img src={question.questionPic} alt="image" />}

--- a/src/lib/core-components/ProgressBar.jsx
+++ b/src/lib/core-components/ProgressBar.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import quiz from './../../docs/quiz';
+
+const ProgressBar = ({ bgcolor, progress, height }) => {
+  const valueofEachProgressUnit = 100 / quiz.questions.length;
+
+  const Parentdiv = {
+    height: height,
+    width: '100%',
+    backgroundColor: 'whitesmoke',
+    borderRadius: 40,
+    margin: 20,
+  };
+
+  const Childdiv = {
+    height: '100%',
+    width: `${valueofEachProgressUnit * progress}%`,
+    backgroundColor: bgcolor,
+    borderRadius: 40,
+    textAlign: 'center',
+  };
+
+  const progressText = {
+    padding: 10,
+    color: 'black',
+    fontWeight: 900,
+  };
+
+  return (
+    <div style={Parentdiv}>
+      <div style={Childdiv}>
+        <span style={progressText}>{`${progress}`}</span>
+      </div>
+    </div>
+  );
+};
+
+ProgressBar.defaultProps = {
+  bgcolor: "#D0D4CA", // Set a default value for bgcolor
+};
+
+export default ProgressBar;


### PR DESCRIPTION
Added progressbar so that user can see quiz progress. This PR fixes #131 issue

I have created a new component called `ProgressBar.jsx` which takes three props `progress`, `height` and `bgcolor`. Using them we can customise the progressbar. 

Please check and let me know if any changes are required.

Here is how it looks:

✅ First question
![first_question](https://github.com/wingkwong/react-quiz-component/assets/33797909/e1af5f77-d083-4886-8679-27da27a25903)

✅ Second question
![second](https://github.com/wingkwong/react-quiz-component/assets/33797909/d56dd6a3-8dac-4509-a7a6-8d16f51d7002)

✅ Third question
![third](https://github.com/wingkwong/react-quiz-component/assets/33797909/12029b3a-41f4-442a-8380-26b5e37d85d3)

✅ Fifth question
![fifth](https://github.com/wingkwong/react-quiz-component/assets/33797909/ef810c93-eec1-4ece-83d7-8c51a434c4e5)

✅ Last question
![last](https://github.com/wingkwong/react-quiz-component/assets/33797909/7ac7f4e8-ed9b-4dc8-8675-84f385110440)

