### PR TITLE
Fixes repeat question on shuffle

### DIFF
--- a/src/lib/Core.jsx
+++ b/src/lib/Core.jsx
@@ -37,11 +37,7 @@ function Core({
 
   useEffect(() => {
     setActiveQuestion(questions[currentQuestionIndex]);
-  }, [questions]);
-
-  useEffect(() => {
-    setActiveQuestion(questions[currentQuestionIndex]);
-  }, [currentQuestionIndex]);
+  }, [currentQuestionIndex, questions]);
 
   useEffect(() => {
     const { answerSelectionType } = activeQuestion;

--- a/src/lib/Core.jsx
+++ b/src/lib/Core.jsx
@@ -37,6 +37,10 @@ function Core({
 
   useEffect(() => {
     setActiveQuestion(questions[currentQuestionIndex]);
+  }, [questions]);
+
+  useEffect(() => {
+    setActiveQuestion(questions[currentQuestionIndex]);
   }, [currentQuestionIndex]);
 
   useEffect(() => {


### PR DESCRIPTION
There is an issue when the shuffle is enabled in the Quiz component. It repeats questions, this is happening due to the view not re-rendering when the `shuffleQuestions` function is done shuffling the questions, so the old question still happen to be in the view.

Example:  

<img width="585" alt="Screen Shot 2024-01-02 at 3 22 05 PM" src="https://github.com/wingkwong/react-quiz-component/assets/12890496/ebc5a977-ed91-4799-887d-d0514cdec486">

This repeats again as Question 5:

<img width="585" alt="Screen Shot 2024-01-02 at 3 22 27 PM" src="https://github.com/wingkwong/react-quiz-component/assets/12890496/f61efeed-09cf-43dd-83cb-a27c01f1cf3e">

Looking at the result page shows that the new shuffled questions.  We can see question 1 correctly displayed
<img width="585" alt="Screen Shot 2024-01-02 at 3 23 29 PM" src="https://github.com/wingkwong/react-quiz-component/assets/12890496/6049f279-9e3f-4cfe-9810-8b12bcd98da0">

This fix resolves the issue by rerendering the Core view and updating the active questions.

```
  useEffect(() => {
    setActiveQuestion(questions[currentQuestionIndex]);
  }, [questions]);
```


