### PR TITLE
feat(locale): adds locale text to answers dropdown filter

### DIFF
--- a/src/lib/core-components/QuizResultFilter.jsx
+++ b/src/lib/core-components/QuizResultFilter.jsx
@@ -14,10 +14,20 @@ function QuizResultFilter({ filteredValue, handleChange, appLocale }) {
   };
 
   const selectedOptionClass = isOpen ? 'selected-open' : '';
+  const selectedValuesLocale = {
+    all: appLocale.resultFilterAll,
+    correct: appLocale.resultFilterCorrect,
+    incorrect: appLocale.resultFilterIncorrect,
+    unanswered: appLocale.resultFilterUnanswered,
+  };
 
   useEffect(() => {
     const handleOutsideClick = (e) => {
-      if (isOpen && dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+      if (
+        isOpen
+        && dropdownRef.current
+        && !dropdownRef.current.contains(e.target)
+      ) {
         setIsOpen(false);
       }
     };
@@ -44,7 +54,7 @@ function QuizResultFilter({ filteredValue, handleChange, appLocale }) {
         tabIndex={0}
       >
         <div className={`selected-option ${selectedOptionClass}`}>
-          {filteredValue === 'all' ? appLocale.resultFilterAll : filteredValue}
+          {selectedValuesLocale[filteredValue]}
         </div>
         <span className={`arrow ${isOpen ? 'up' : 'down'}`} />
       </div>


### PR DESCRIPTION
Added appLocale  label, not just to the "all" filter on the responses page. 

I've encountered this when trying to configure a quiz on a test project. The label on the "all" filter was working properly, like the following (ignore the styles): 

<img width="549" alt="image" src="https://github.com/wingkwong/react-quiz-component/assets/30606824/a9aeaa05-2bc9-4919-9730-7a68a851e549">

On the dropdown, all the locales were shown fine: 

<img width="190" alt="image" src="https://github.com/wingkwong/react-quiz-component/assets/30606824/4f93ce0d-8a8e-48c5-b56d-f1d36a38ca03">

However, when selecting any of the other values, it does not show the locale configured value: 

<img width="186" alt="image" src="https://github.com/wingkwong/react-quiz-component/assets/30606824/977eb747-3f51-4039-b7fa-10f27bb7aba8">

Let me know if this works!