### PR TITLE
Feat: Add control for questionPic size (#68)

### DIFF
--- a/src/lib/Core.jsx
+++ b/src/lib/Core.jsx
@@ -437,7 +437,17 @@ function Core({
                 )}
               />
               {activeQuestion && activeQuestion.questionPic && (
-                <img src={activeQuestion.questionPic} alt="question" />
+                <div className="active-question-pic-container">
+                  <img
+                    src={activeQuestion.questionPic}
+                    alt="question"
+                    style={{
+                      height: activeQuestion.questionPicHeight ?? 'auto',
+                      width: activeQuestion.questionPicWidth ?? 'auto',
+                      maxWidth: '100%',
+                    }}
+                  />
+                </div>
               )}
               {activeQuestion
                 && renderTags(

--- a/src/lib/styles.css
+++ b/src/lib/styles.css
@@ -58,6 +58,11 @@
   font-size: 30px;
 }
 
+.react-quiz-container .active-question-pic-container {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+}
 
 .react-quiz-container .questionModal .alert {
   padding: 20px;


### PR DESCRIPTION
- The image size can now be customized or dynamically adjusted as per requirements.
- Introduced `questionPicWidth` and `questionPicHeight` props to allow manual size control.